### PR TITLE
Include missing <memory> for unique_ptr (clang is too lenient)

### DIFF
--- a/src/common/configmanager/configmanager.cpp
+++ b/src/common/configmanager/configmanager.cpp
@@ -72,10 +72,6 @@ int CConfigManager::init(void)
         logger.log(LOG_ERROR, "No simulator section set in config [%s]", nfex.what());
         return RETURN_ERROR;
     }
-    catch (std::exception &e) {
-        logger.log(LOG_ERROR, "%s", e.what());
-        return RETURN_ERROR;
-    }
     catch (std::logic_error &e) {
         logger.log(LOG_ERROR, "%s", e.what());
         return RETURN_ERROR;

--- a/src/common/device/device.h
+++ b/src/common/device/device.h
@@ -4,6 +4,7 @@
 #include "../log/clog.h"
 #include <libconfig.h++>
 #include <string>
+#include <memory>
 
 class Device
 {

--- a/src/test/test_main.cpp
+++ b/src/test/test_main.cpp
@@ -3,7 +3,7 @@
 #include <thread>
 
 #include "plugins/common/queue/concurrent_queue.h"
-#include "plugins/common/simHubDevicePlugin.h"
+#include "plugins/common/simhubdeviceplugin.h"
 
 /**
  * simple state management class used by the PluginTests


### PR DESCRIPTION
 - ...and we think clang is also a little bit silly
 - remove redundant catch (catching more general case of existing type)
   -> GCC you are my only friend
 - another include filename case fix
   -> one must remove ones digit and setup that case sensitive build volume
      on one's mac