### PR TITLE
First cut of work to pass plugin specific settings through - REVIEW ONLY

### DIFF
--- a/premake4.lua
+++ b/premake4.lua
@@ -5,7 +5,9 @@ newaction {
    description = "clean the software",
    execute     = function ()
       print("clean the build...")
-      os.rmdir("./build")
+      os.rmdir("./obj")
+      os.remove("./*.make")
+      os.remove("./Makefile")
       print("done.")
    end
 }

--- a/premake4.lua
+++ b/premake4.lua
@@ -113,6 +113,7 @@ solution "simhub"
         targetname "prepare3d"
         targetdir ("bin/plugins")
         links { 'uv',
+                'config++',
                 'pthread'}
 		files { "src/libs/plugins/prepare3d/**.h",
                 "src/libs/plugins/common/**.cpp",
@@ -127,7 +128,7 @@ solution "simhub"
 					  "src/libs/queue" }
         buildoptions { "--std=c++14" }
 
-project "simplug_devicesource"
+    project "simplug_devicesource"
 	    kind "SharedLib"
 		language "C++"
         targetname "pokey"
@@ -143,5 +144,7 @@ project "simplug_devicesource"
                       "src/libs",
                       "src/libs/variant/include/mpark",
 					  "src/libs/queue" }
+        links { 'config++',
+                'pthread'}
         buildoptions { "--std=c++14" }
 		

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -41,8 +41,6 @@ int main(int argc, char *argv[])
     ConfigManager config(cli.get<std::string>("config"));
     std::shared_ptr<SimHubEventController> simhubController = SimHubEventController::EventControllerInstance();
 
-    simhubController->setConfigManager(&config);
-
 #if defined(_AWS_SDK)
     awsHelper.init();
     if (cli.get<bool>("polly")) {
@@ -54,6 +52,9 @@ int main(int argc, char *argv[])
         logger.log(LOG_ERROR, "Could not initialise configuration");
         exit(1);
     }
+
+    simhubController->loadPokeyPlugin();
+    simhubController->loadPrepare3dPlugin();
 
     simhubController->runEventLoop([=](std::shared_ptr<Attribute> value) {
         static size_t counter = 0;
@@ -71,6 +72,7 @@ int main(int argc, char *argv[])
 #if defined(_AWS_SDK)
     awsHelper.polly()->say("system ready %d %s", 1, "test");
 #endif
+
 // Source el("element", "desc");
 
 // Attribute attr;

--- a/src/app/simhub.h
+++ b/src/app/simhub.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <thread>
+#include <list>
 
 #include "elements/attributes/attribute.h"
 #include "libs/plugins/common/queue/concurrent_queue.h"
@@ -30,7 +31,7 @@ protected:
 
     void prepare3dEventCallback(SPHANDLE eventSource, void *eventData);
     void pokeyEventCallback(SPHANDLE eventSource, void *eventData);
-    simplug_vtable loadPlugin(std::string dylibName, EnqueueEventHandler eventCallback);
+    simplug_vtable loadPlugin(std::string dylibName, std::list<libconfig::Setting *> &pluginConfigs, EnqueueEventHandler eventCallback);
     void terminate(void);
     void shutdownPlugin(simplug_vtable &pluginMethods);
 
@@ -38,15 +39,21 @@ protected:
     simplug_vtable _prepare3dMethods;
     simplug_vtable _pokeyMethods;
     ConfigManager *_configManager;
+    
+    // -- temp solution to plugin device configuration conundrum
+    std::list<libconfig::Setting *> _pokeyDeviceConfigs;
+    std::list<libconfig::Setting *> _prepare3dDeviceConfigs;
 
 public:
     virtual ~SimHubEventController(void);
-
     void loadPrepare3dPlugin(void);
     void loadPokeyPlugin(void);
-
     bool deliverPokeyPluginValue(std::shared_ptr<Attribute> value);
-    void setConfigManager(ConfigManager *configManager) { _configManager = configManager; };
+    void setConfigManager(ConfigManager *configManager);
+
+    // -- temp solution to plugin device configuration conundrum
+    void addPrepare3dConfig(libconfig::Setting * prepare3dConfig) { assert(prepare3dConfig != NULL); _prepare3dDeviceConfigs.push_back(prepare3dConfig); };;
+    void addPokeyConfig(libconfig::Setting *pokeyConfig) { assert(pokeyConfig != NULL); _pokeyDeviceConfigs.push_back(pokeyConfig); };
 
     template <class F> void runEventLoop(F &&eventProcessorFunctor);
 

--- a/src/common/configmanager/configmanager.cpp
+++ b/src/common/configmanager/configmanager.cpp
@@ -104,6 +104,8 @@ int ConfigManager::init(std::shared_ptr<SimHubEventController> simhubController)
         return RETURN_ERROR;
     }
 
+    simhubController->setConfigManager(this);
+
     return RETURN_OK;
 }
 

--- a/src/common/configmanager/deviceConfigManager/deviceConfigManager.cpp
+++ b/src/common/configmanager/deviceConfigManager/deviceConfigManager.cpp
@@ -28,18 +28,13 @@ DeviceConfigManager::DeviceConfigManager(libconfig::Config *config,
 
             if (type == PREPARE3D) {
                 logger.log(LOG_INFO, " - Creating %s simulator device", type.c_str());
-                try {
-                    _simConfigManager.reset(new SimConfigManager(tmpDeviceConfig, simhubController));
-                    continue;
-                }
-                catch (libconfig::SettingNotFoundException &nfex) {
-                    logger.log(LOG_ERROR, "No simulator section set in config [%s]", nfex.what());
-                    continue;
-                }
-                catch (std::logic_error &e) {
-                    logger.log(LOG_ERROR, "%s", e.what());
-                    continue;
-                }
+
+                simhubController->addPrepare3dConfig(tmpDeviceConfig);
+            }
+            else if (type == POKEYDEV) {
+                logger.log(LOG_INFO, " - Creating %s simulator device", type.c_str());
+    
+                simhubController->addPokeyConfig(tmpDeviceConfig);
             }
             id = tmpDeviceConfig->lookup("id").c_str();
         }

--- a/src/common/configmanager/simConfigManager/simConfigManager.cpp
+++ b/src/common/configmanager/simConfigManager/simConfigManager.cpp
@@ -8,7 +8,9 @@
  *
  *   @return nothing
  */
-SimConfigManager::SimConfigManager(libconfig::Setting *setting, std::shared_ptr<SimHubEventController> simhubController, std::string pluginDir)
+SimConfigManager::SimConfigManager(libconfig::Setting *setting, 
+                                   std::shared_ptr<SimHubEventController> simhubController,
+                                   std::string pluginDir)
     : _simConfig(setting)
     , _simhubController(simhubController)
     , _pluginDir(pluginDir)
@@ -16,9 +18,6 @@ SimConfigManager::SimConfigManager(libconfig::Setting *setting, std::shared_ptr<
     if (!validateConfig()) {
         throw std::runtime_error("[SimConfigManager] Unable to validate config.");
     }
-
-    _simhubController->loadPrepare3dPlugin();
-    _simhubController->loadPokeyPlugin();
 }
 
 /**

--- a/src/common/configmanager/simConfigManager/simConfigManager.h
+++ b/src/common/configmanager/simConfigManager/simConfigManager.h
@@ -19,6 +19,7 @@
 #define RETURN_OK 1
 #define RETURN_ERROR 0
 #define PREPARE3D "prepare3d"
+#define POKEYDEV "pokey"
 
 #include "simhub.h"
 

--- a/src/libs/plugins/common/private/pluginstatemanager.cpp
+++ b/src/libs/plugins/common/private/pluginstatemanager.cpp
@@ -11,9 +11,6 @@ PluginStateManager::PluginStateManager(LoggingFunctionCB logger)
 
 PluginStateManager::~PluginStateManager(void)
 {
-
-    // TODO: move these into proper test class
-    //_testEventThread.join();
 }
 
 void PluginStateManager::runTestEventLoop(void)
@@ -29,6 +26,13 @@ void PluginStateManager::runTestEventLoop(void)
 int PluginStateManager::bindConfigValues(char *group_name, genericTLV **values, int count)
 {
     std::cout << "bindConfigValues: " << group_name << ", " << count << std::endl;
+    return 0;
+}
+
+//! just queue up a copy of the device settings for use in preflightComplete
+int PluginStateManager::configPassthrough(libconfig::Setting* pluginConfiguration)
+{
+    _pluginConfigurations.push_back(pluginConfiguration);
     return 0;
 }
 

--- a/src/libs/plugins/common/private/pluginstatemanager.h
+++ b/src/libs/plugins/common/private/pluginstatemanager.h
@@ -1,8 +1,11 @@
 #ifndef __PLUGINSTATEMANAGER_H
 #define __PLUGINSTATEMANAGER_H
 
-#include "common/simhubdeviceplugin.h"
 #include <thread>
+#include <libconfig.h++>
+#include <list>
+
+#include "common/simhubdeviceplugin.h"
 
 #define PREFLIGHT_OK 0
 #define PREFLIGHT_FAIL 1
@@ -29,11 +32,15 @@ protected:
     void *_callbackArg;
     LoggingFunctionCB _logger;
 
+    //! list of device settings for use in preflightComplete
+    std::list<libconfig::Setting *> _pluginConfigurations;
+
 public:
     PluginStateManager(LoggingFunctionCB logger);
     virtual ~PluginStateManager(void);
 
     virtual int bindConfigValues(char *group_name, genericTLV **values, int count);
+    virtual int configPassthrough(libconfig::Setting *pluginConfiguration);
     virtual int preflightComplete(void);
     virtual void commenceEventing(EnqueueEventHandler enqueueCallback, void *arg);
     virtual int deliverValue(genericTLV *value);

--- a/src/libs/plugins/common/simhubdeviceplugin.h
+++ b/src/libs/plugins/common/simhubdeviceplugin.h
@@ -45,6 +45,9 @@ typedef struct {
     //! pass in named config key/val pair group
     int (*simplug_bind_config_values)(SPHANDLE plugin_instance, char *group_name, genericTLV **values, int count);
 
+    //! pass through kludge until we split out config files
+    int (*simplug_config_passthrough)(SPHANDLE plugin_instance, void* libconfig_instance);
+
     //! pre-flight checks method
     int (*simplug_preflight_complete)(SPHANDLE plugin_instance);
 
@@ -95,6 +98,10 @@ inline int simplug_bootstrap(const char *plugin_path, simplug_vtable *plugin_vta
 
     plugin_vtable->simplug_bind_config_values = (int (*)(SPHANDLE, char *, genericTLV **, int))dlsym(handle, "simplug_bind_config_values");
     if (!plugin_vtable->simplug_bind_config_values)
+        return -1;
+
+    plugin_vtable->simplug_config_passthrough = (int (*)(SPHANDLE, void *))dlsym(handle, "simplug_config_passthrough");
+    if (!plugin_vtable->simplug_config_passthrough)
         return -1;
 
     plugin_vtable->simplug_preflight_complete = (int (*)(SPHANDLE))dlsym(handle, "simplug_preflight_complete");

--- a/src/libs/plugins/pokey/pokeysource_main.cpp
+++ b/src/libs/plugins/pokey/pokeysource_main.cpp
@@ -15,6 +15,11 @@ int simplug_bind_config_values(SPHANDLE plugin_instance, char *group_name, gener
     return static_cast<PluginStateManager *>(plugin_instance)->bindConfigValues(group_name, values, count);
 }
 
+int simplug_config_passthrough(SPHANDLE plugin_instance, void* libconfig_instance)
+{
+     return static_cast<PluginStateManager *>(plugin_instance)->configPassthrough(static_cast<libconfig::Setting *>(libconfig_instance));
+} 
+
 int simplug_preflight_complete(SPHANDLE plugin_instance)
 {
     return static_cast<PluginStateManager *>(plugin_instance)->preflightComplete();
@@ -49,5 +54,23 @@ int PokeyDevicePluginStateManager::deliverValue(genericTLV *value)
 {
     assert(value);
     _logger(LOG_INFO, "Pokey plugin to deliver: %s", value->name);
+    return 0;
+}
+
+int PokeyDevicePluginStateManager::preflightComplete(void)
+{
+    // -- at this point we should iterate over our list of libconfig::Setting *'s
+    //    and apply the values in  each to the devices we can discover on our network
+    //    - fail out appropriately if we can't find all the devices referred to in the
+    //      settings list and also if there are more devices discovered than settings
+    //      - e.g. dev_missing_config err and config_missing_dev err or something like
+    //        that
+
+    _logger(LOG_INFO, "Pokey plugin to discover all connected devices and apply matching elements in _pluginConfigurations to each");
+
+    for (libconfig::Setting *setting: _pluginConfigurations) {
+        _logger(LOG_INFO, "got setting for pokey device: %s", setting->lookup("name").c_str());
+    }
+
     return 0;
 }

--- a/src/libs/plugins/pokey/pokeysource_main.h
+++ b/src/libs/plugins/pokey/pokeysource_main.h
@@ -16,6 +16,7 @@ public:
     PokeyDevicePluginStateManager(LoggingFunctionCB logger) : PluginStateManager(logger) {};
 
     virtual int deliverValue(genericTLV *value);
+    virtual int preflightComplete(void);
 };
 
 #endif

--- a/src/libs/plugins/prepare3d/main.cpp
+++ b/src/libs/plugins/prepare3d/main.cpp
@@ -20,6 +20,11 @@ int simplug_bind_config_values(SPHANDLE plugin_instance, char *group_name, gener
     return static_cast<PluginStateManager *>(plugin_instance)->bindConfigValues(group_name, values, count);
 }
 
+int simplug_config_passthrough(SPHANDLE plugin_instance, void* libconfig_instance)
+{
+     return static_cast<PluginStateManager *>(plugin_instance)->configPassthrough(static_cast<libconfig::Setting *>(libconfig_instance));
+}
+
 int simplug_preflight_complete(SPHANDLE plugin_instance)
 {
     return static_cast<PluginStateManager *>(plugin_instance)->preflightComplete();


### PR DESCRIPTION
 - place holder implementation at this point that simply passes through
   a libconfig::Setting * as a void * <- this should probably be
   redone by making the plugin configuration a separate file (which
   would allow plugin implementers to define their own config standard)

 - this leaves much of the pre-existing config loading code unused for now
   -> should look at moving the validation code into the plugins and then
      have the main app just validate the entries in its mapping table after
      (for example, have a plugin api that allows the app to confirm a the
      name and type of a given source/destination in the plugin)